### PR TITLE
Enable auto_registration and disable manage_repos before checking

### DIFF
--- a/os_tests/tests/test_general_test.py
+++ b/os_tests/tests/test_general_test.py
@@ -271,16 +271,16 @@ int main(int argc, char *argv[])
         product_id = utils_lib.get_product_id(self)
         if float(product_id) < 8.4:
             self.skipTest('skip in earlier than el8.4')
-        self.log.info("Auto registeration only supports aws platform for now.")
+        self.log.info("Auto registeration only supports AWS and Azure platforms for now.")
 
+        cmd = "sudo subscription-manager config --rhsmcertd.auto_registration=1 --rhsm.manage_repos=0 --rhsmcertd.auto_registration_interval=1"
+        utils_lib.run_cmd(self, cmd, expect_ret=0, msg='try to enable auto_registration, disable managed_repos and change inverval from 60mins to 1min')
+        cmd = "sudo systemctl restart rhsmcertd"
+        utils_lib.run_cmd(self, cmd, expect_ret=0, msg='try to restart rhsmcertd service')
         cmd = "sudo subscription-manager config"
         utils_lib.run_cmd(self, cmd, expect_ret=0, expect_kw="auto_registration = 1,manage_repos = 0", msg='try to check subscription-manager config')
-        cmd = "sudo systemctl is-enabled rhsmcertd"
+        cmd = "sudo systemctl is-active rhsmcertd"
         utils_lib.run_cmd(self, cmd, expect_ret=0, msg='try to check rhsmcertd enabled')
-        cmd = "sudo subscription-manager config --rhsmcertd.auto_registration_interval=1"
-        utils_lib.run_cmd(self, cmd, expect_ret=0, msg='try to change rhsmcertd.auto_registration_interval from 60min to 1min')
-        cmd = "sudo systemctl restart rhsmcertd"
-        utils_lib.run_cmd(self, cmd, expect_ret=0, msg='restart rhsmcertd')
         start_time = time.time()
         timeout = 600
         interval = 60


### PR DESCRIPTION
If check the auto_registration and manage_repos directly, the case fails if it is not pre-setup. So add the config step at the beginning to make it adapt to all the images.

Signed-off-by: Yuxin Sun <yuxisun@redhat.com>