### PR TITLE
enhance kvm guest identification and searching for pci devices

### DIFF
--- a/os_tests/tests/test_general_check.py
+++ b/os_tests/tests/test_general_check.py
@@ -23,8 +23,7 @@ class TestGeneralCheck(unittest.TestCase):
         '''
         time_start = utils_lib.run_cmd(self, "date '+%T'", msg='retrive test system current time')
         self.log.info("Check no permission denied at nfs server - bug1655493")
-        cmd = 'sudo yum install -y nfs-utils'
-        utils_lib.run_cmd(self, cmd, msg='Install nfs-utils')
+        utils_lib.is_pkg_installed(self,pkg_name='nfs-utils')
         output = utils_lib.run_cmd(self, 'uname -r', expect_ret=0)
 
         if 'el7' in output or 'el6' in output:
@@ -58,9 +57,9 @@ class TestGeneralCheck(unittest.TestCase):
             expect_clocks = 'xen,tsc,hpet,acpi_pm'
         elif 'aarch64' in output:
             expect_clocks = 'arch_sys_counter'
-        elif 'AuthenticAMD' in output and 'KVM' in output:
+        elif 'AuthenticAMD' in output and 'KVM' in output and not utils_lib.is_metal(self):
             expect_clocks = 'kvm-clock,tsc,acpi_pm'
-        elif 'GenuineIntel' in output and 'KVM' in output:
+        elif 'GenuineIntel' in output and 'KVM' in output and not utils_lib.is_metal(self):
             expect_clocks = 'kvm-clock,tsc,acpi_pm'
         else:
             expect_clocks = 'tsc,hpet,acpi_pm'

--- a/os_tests/tests/test_general_test.py
+++ b/os_tests/tests/test_general_test.py
@@ -567,6 +567,11 @@ grep -i pci|grep n1' % boot_pci
             self,
             'sudo virsh nodedev-list|grep %s |tail -1' % tmp_pci,
             msg='pick up device to detach')
+        pci_dev_1 = re.findall('pci_.*',pci_dev_1)
+        if len(pci_dev_1) > 0:
+            pci_dev_1= pci_dev_1[0]
+        else:
+            self.fail("no {} found in output".format(tmp_pci))
         if pci_dev_1.endswith('1'):
             pci_dev_0 = pci_dev_1.rstrip('1') + '0'
             utils_lib.run_cmd(self,


### PR DESCRIPTION
- el9 lscpu output more information like Vulnerabilities, so add
  more checking.
  eg. KVM: Mitigation: VMX disabled
- 'virsh nodedev-list' has extra output when hit some exception,
  so ignore such output and pick up starting with pci only.
  eg.virsh nodedev-list|grep 0000_18_00_1|tail -1
     setlocale: No such file or directory
     pci_0000_18_00_1

Signed-off-by: Xiao Liang <xiliang@redhat.com>