### PR TITLE
Add junit output

### DIFF
--- a/os_tests/templates/sum.xml
+++ b/os_tests/templates/sum.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0"?>
+<testsuites>
+  <testsuite name="os-tests" time="{{ result.run_time }}" tests="{{ result.total }}" errors="{{ result.case_error }}" skipped="{{ result.case_skip }}" failures="{{ result.case_fail }}">
+  {% for row in result.table_rows %}
+  <testcase name="{{ row[1] }}">
+    {% if row[2] == 'FAIL' %}
+    <failure>{{ row[3] }}</failure>
+    {% endif %}
+    {% if row[2] == 'ERROR' %}
+    <error>{{ row[3] }}</error>
+    {% endif %}
+    {% if row[2] == 'SKIP' %}
+    <skipped />
+    {% endif %}
+  </testcase>
+  {% endfor %}
+  </testsuite>
+</testsuites>


### PR DESCRIPTION
Jenkins and other CI system use unit file format to render tests results.
This patch add the generation of junit file.

Add some refactoring to separate the generation of the test result object, and the printer part.