### PR TITLE
(fix) utils_lib: Correct subscription-manager status return status

### DIFF
--- a/os_tests/libs/utils_lib.py
+++ b/os_tests/libs/utils_lib.py
@@ -1360,8 +1360,8 @@ def is_rhsm_registered(test_instance, cancel_case=False, timeout=600, rmt_node=N
         test_instance {Test instance} -- test instance
     '''
     cmd = "sudo subscription-manager status"
-    out = run_cmd(test_instance, cmd, msg='try to check subscription status', rmt_node=rmt_node, vm=vm)
-    if 'Red Hat Enterprise Linux' in out or 'Simple Content Access' in out:
+    status = run_cmd(test_instance, cmd, msg='try to check subscription status', rmt_node=rmt_node, vm=vm, ret_status=True, ret_out=False)
+    if status == 0:
         return True
     else:
         if cancel_case: test_instance.skipTest("Unable to register")

--- a/os_tests/tests/test_general_test.py
+++ b/os_tests/tests/test_general_test.py
@@ -532,9 +532,7 @@ int main(int argc, char *argv[])
             out = utils_lib.run_cmd(self, cmd, msg='try to check subscription identity')
             cmd = "sudo subscription-manager list --installed"
             out = utils_lib.run_cmd(self, cmd, msg='try to list currently installed on the system')
-            cmd = "sudo subscription-manager status"
-            status = utils_lib.run_cmd(self, cmd, msg='try to check subscription status', ret_status=True, ret_out=False)
-            if status == 0:
+            if utils_lib.is_rhsm_registered(self, cancel_case=True):
                 self.log.info("auto subscription registered completed")
                 cmd = "sudo insights-client --register"
                 utils_lib.run_cmd(self, cmd, msg='check if insights-client can register successfully')


### PR DESCRIPTION
The output message of 'subscription-manager status' has changed. Using just the return code to determine register status.

Fixes: 2b38965a614d3 ("Add rhsm is_rhsm_registered, enable_auto_registration, rhsm_register, rhsm_unregister")
Signed-off-by: Li Tian <litian@redhat.com>

Resolves: #629